### PR TITLE
do not add a trailing slash if there are no extra args

### DIFF
--- a/nscrestc.go
+++ b/nscrestc.go
@@ -87,11 +87,9 @@ func main() {
 		os.Exit(3)
 	}
 
-	if len(flag.Args()) == 0 {
-		Url.Path += "/"
-	} else if len(flag.Args()) == 1 {
+	if len(flag.Args()) == 1 {
 		Url.Path += "/query/" + flag.Arg(0)
-	} else {
+	} else if len(flag.Args()) != 0 {
 		Url.Path += "/query/" + flag.Arg(0)
 		parameters := url.Values{}
 		for i, a := range flag.Args() {


### PR DESCRIPTION
Before:
$ ./nscrestc.exe -k -p 12345678 -u "https://127.0.0.1:8443/query/check_cpu?show-all"
UNKNOWN: Get https://127.0.0.1:8443/query/check_cpu/?show-all: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)

After:
$ ./nscrestc.exe -k -p 12345678 -u "https://127.0.0.1:8443/query/check_cpu?show-all"
UNKNOWN: Get https://127.0.0.1:8443/query/check_cpu?show-all: net/http: request canceled while waiting for connection (Client.Timeout exceeded while awaiting headers)
