### PR TITLE
Adding check for HTTP 403 (forbidden)

### DIFF
--- a/check_nsc_web.go
+++ b/check_nsc_web.go
@@ -253,6 +253,13 @@ func main() {
 	}
 	defer res.Body.Close()
 
+	// check http status code
+	// getting 403 here means we're not allowed on the target (e.g. allowed hosts)
+	if res.Status == "403" {
+		fmt.Println("HTTP 403: Forbidden.")
+		os.Exit(3)
+	}
+
 	if flagVerbose {
 		dumpres, err := httputil.DumpResponse(res, true)
 		if err != nil {


### PR DESCRIPTION
This adds a simple message if the status code is 403 when connecting to the target.
So the output will be detailed without using the verbose flag. Additionally the return code is 3.

Without this additional output only the message "UNKNOWN: The resultpayload size is 0" is displayed. You were forced to use "verbose" to examine the real error (which was that the executing host was missing in allowed hosts on the target). 