### PR TITLE
Fix unsolicited response

### DIFF
--- a/check_nsc_web.go
+++ b/check_nsc_web.go
@@ -162,7 +162,7 @@ func main() {
 
 	if flagVersion {
 		fmt.Fprintln(os.Stderr, "check_nsc_web v"+AppVersion)
-		os.Exit(0)
+		os.Exit(3)
 	}
 	seen := make(map[string]bool)
 	flag.Visit(func(f *flag.Flag) {

--- a/check_nsc_web.go
+++ b/check_nsc_web.go
@@ -325,15 +325,15 @@ func main() {
 
 			nagiosMessage = strings.TrimSpace(l.Message)
 
-			val := ""
-			uni := ""
-			war := ""
-			cri := ""
-			min := ""
-			max := ""
 			for m, p := range l.Perf {
 				// FIXME what if crit is set but not warn - there need to be unfilled semicolons
 				// REFERENCE 'label'=value[UOM];[warn];[crit];[min];[max]
+				val := ""
+				uni := ""
+				war := ""
+				cri := ""
+				min := ""
+				max := ""
 				if p.Value != nil {
 					val = strconv.FormatFloat(*(p.Value), 'f', flagFloatround, 64)
 				} else {


### PR DESCRIPTION
add workaround for "Unsolicited response received on idle HTTP channel starting with"
    
sometimes nsc web sends additional output which golang simply logs to stderr. Since we
cannot change that, we set the devnull logger to discard the output.